### PR TITLE
Improve option calculations and closing workflow

### DIFF
--- a/backend/models/Contract.ts
+++ b/backend/models/Contract.ts
@@ -13,7 +13,18 @@ const contractSchema = new mongoose.Schema({
   contracts: { type: Number, required: true, min: 1, default: 1 },
   expectedCreditOrDebit: { type: Number, required: true },
   notes: { type: String, trim: true },
-  status: { type: String, enum: ['open', 'closed', 'expired'], default: 'open' }
+  status: { type: String, enum: ['open', 'closed', 'expired'], default: 'open' },
+  finalUnderlyingPrice: { type: Number },
+  finalProfitLoss: { type: Number },
+  closedDate: { type: Date },
+  analysis: {
+    wasProfit: Boolean,
+    reasonForOutcome: String,
+    lessonsLearned: String,
+    marketConditions: String,
+    whatWentRight: String,
+    whatWentWrong: String
+  }
 }, {
   timestamps: true
 });

--- a/src/__tests__/utils/profitLossCalculator.test.ts
+++ b/src/__tests__/utils/profitLossCalculator.test.ts
@@ -39,4 +39,18 @@ describe('Profit/Loss Calculator', () => {
     // At expiration: max(0, 95 - 100) * 1 * 100 + (-5 * 1 * 100) = 0 - 500 = -500
     expect(result.ifExercisedAtExpiration).toBe(-500);
   });
+
+  test('calculates profit for short call', () => {
+    const shortContract: OptionContract = {
+      ...mockContract,
+      buyOrSell: 'sell',
+      expectedCreditOrDebit: 5,
+    };
+    const result = calculateProfitLoss(shortContract, 95, 1);
+
+    // If sold now: 5*100 - 1*100 = 400
+    expect(result.ifSoldNow).toBe(400);
+    // At expiration: premium (500) - intrinsic (0) = 500
+    expect(result.ifExercisedAtExpiration).toBe(500);
+  });
 });

--- a/src/components/contracts/ContractDetail.tsx
+++ b/src/components/contracts/ContractDetail.tsx
@@ -3,6 +3,7 @@ import type { OptionContract } from '../../models/OptionContract';
 import { calculateProfitLoss, formatProfitLoss } from '../../utils/profitLossCalculator';
 import Button from '../common/Button';
 import Input from '../common/Input';
+import { useContracts } from '../../context/ContractsContext';
 
 interface ContractDetailProps {
   contract: OptionContract;
@@ -12,6 +13,10 @@ interface ContractDetailProps {
 const ContractDetail: React.FC<ContractDetailProps> = ({ contract, onBack }) => {
   const [currentUnderlyingPrice, setCurrentUnderlyingPrice] = useState<number>(contract.strikePrice);
   const [currentOptionPrice, setCurrentOptionPrice] = useState<number>(contract.bidPrice);
+  const [showCloseModal, setShowCloseModal] = useState(false);
+  const [closeUnderlyingPrice, setCloseUnderlyingPrice] = useState(contract.strikePrice);
+  const [closeOptionPrice, setCloseOptionPrice] = useState(contract.bidPrice);
+  const { closeContract } = useContracts();
 
   const profitLoss = calculateProfitLoss(contract, currentUnderlyingPrice, currentOptionPrice);
 
@@ -28,6 +33,12 @@ const ContractDetail: React.FC<ContractDetailProps> = ({ contract, onBack }) => 
 
   const getProfitLossColor = (amount: number) => {
     return amount >= 0 ? 'text-green-600' : 'text-red-600';
+  };
+
+  const handleCloseContract = async () => {
+    await closeContract(contract.id, closeUnderlyingPrice, closeOptionPrice);
+    setShowCloseModal(false);
+    onBack();
   };
 
   return (
@@ -127,6 +138,44 @@ const ContractDetail: React.FC<ContractDetailProps> = ({ contract, onBack }) => 
           </div>
         </div>
       </div>
+
+      <div className="mt-6 flex justify-end">
+        <Button onClick={() => setShowCloseModal(true)}>
+          Close Position
+        </Button>
+      </div>
+
+      {showCloseModal && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+          <div className="bg-white rounded-2xl p-6 max-w-md mx-4 shadow-2xl">
+            <h3 className="text-lg font-semibold text-gray-900 mb-4">Close Contract</h3>
+            <div className="space-y-4 mb-6">
+              <Input
+                label="Underlying Price"
+                type="number"
+                step="0.01"
+                value={closeUnderlyingPrice}
+                onChange={e => setCloseUnderlyingPrice(parseFloat(e.target.value) || 0)}
+              />
+              <Input
+                label="Option Price"
+                type="number"
+                step="0.01"
+                value={closeOptionPrice}
+                onChange={e => setCloseOptionPrice(parseFloat(e.target.value) || 0)}
+              />
+            </div>
+            <div className="flex gap-3">
+              <Button variant="secondary" onClick={() => setShowCloseModal(false)} className="flex-1">
+                Cancel
+              </Button>
+              <Button onClick={handleCloseContract} className="flex-1">
+                Close
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/contracts/ExpiredOptionsPage.tsx
+++ b/src/components/contracts/ExpiredOptionsPage.tsx
@@ -233,6 +233,17 @@ const ExpiredOptionsPage: React.FC<ExpiredOptionsPageProps> = ({ onBack, onExpir
                     className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                     placeholder="Enter final stock price"
                   />
+                  {finalPrice > 0 && (
+                    <p className="mt-1 text-sm font-medium">
+                      {selectedContract.optionType === 'call'
+                        ? finalPrice > selectedContract.strikePrice
+                          ? 'In the money'
+                          : 'Out of the money'
+                        : finalPrice < selectedContract.strikePrice
+                          ? 'In the money'
+                          : 'Out of the money'}
+                    </p>
+                  )}
                 </div>
                 
                 <div>

--- a/src/components/docs/OptionCalculations.tsx
+++ b/src/components/docs/OptionCalculations.tsx
@@ -17,9 +17,10 @@ export const calculatePayoff = (simulation: StrategySimulation) => {
   } else if (simulation.strategy === 'vertical-spread') {
     const buyStrike = simulation.buyStrike || 100;
     const sellStrike = simulation.sellStrike || 105;
-    const itm = simulation.stockPrice < buyStrike && simulation.stockPrice > sellStrike;
-    const payoff = Math.max(Math.min(buyStrike - simulation.stockPrice, buyStrike - sellStrike) - simulation.premium, -simulation.premium);
-    const maxReturn = buyStrike - sellStrike - simulation.premium;
+    const intrinsic = Math.max(0, simulation.stockPrice - buyStrike);
+    const payoff = Math.min(intrinsic, sellStrike - buyStrike) - simulation.premium;
+    const itm = simulation.stockPrice > buyStrike;
+    const maxReturn = sellStrike - buyStrike - simulation.premium;
     const maxLoss = -simulation.premium;
     return { itm, payoff, maxReturn, maxLoss };
   }

--- a/src/utils/profitLossCalculator.ts
+++ b/src/utils/profitLossCalculator.ts
@@ -42,7 +42,9 @@ export const calculateProfitLoss = (
   }
 
   // P/L if closed now
-  const cashOnClose = currentPrice * contracts * 100 * (buyOrSell === 'buy' ? -1 : 1);
+  // When closing a long position you receive cash, while closing a short
+  // position requires paying cash to buy it back. Adjust the sign accordingly.
+  const cashOnClose = currentPrice * contracts * 100 * (buyOrSell === 'buy' ? 1 : -1);
   const ifSoldNow = totalPremium + cashOnClose;
 
   // P/L at expiration


### PR DESCRIPTION
## Summary
- fix sign logic in `calculateProfitLoss`
- improve vertical spread payoff calculations
- allow contracts to be closed with new context method
- show a close position modal on contract detail
- show ITM/OTM hint in expire contract modal
- extend backend contract schema
- add regression test for short call logic

## Testing
- `npx vitest run` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68717f5db1248330a4dd94de18a98add