### PR TITLE
Improve options workflows

### DIFF
--- a/src/components/contracts/CloseContractModal.tsx
+++ b/src/components/contracts/CloseContractModal.tsx
@@ -1,0 +1,70 @@
+import React, { useState } from 'react';
+import type { OptionContract } from '../../models/OptionContract';
+import { useContracts } from '../../context/ContractsContext';
+import { calculateProfitLoss, formatProfitLoss } from '../../utils/profitLossCalculator';
+import Button from '../common/Button';
+
+interface CloseContractModalProps {
+  contract: OptionContract;
+  onDone: () => void;
+  onCancel: () => void;
+}
+
+const CloseContractModal: React.FC<CloseContractModalProps> = ({ contract, onDone, onCancel }) => {
+  const { closeContract } = useContracts();
+  const [optionPrice, setOptionPrice] = useState<number>(contract.bidPrice);
+  const [underlyingPrice, setUnderlyingPrice] = useState<number>(contract.strikePrice);
+
+  const result = calculateProfitLoss(contract, underlyingPrice, optionPrice);
+
+  const itm = contract.optionType === 'call'
+    ? underlyingPrice > contract.strikePrice
+    : underlyingPrice < contract.strikePrice;
+
+  const handleClose = async () => {
+    await closeContract(contract.id, optionPrice, underlyingPrice);
+    onDone();
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-white rounded-2xl p-6 max-w-md mx-4 shadow-2xl w-full">
+        <h3 className="text-lg font-semibold text-gray-900 mb-4">Close Contract</h3>
+        <div className="space-y-4 mb-6">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Closing Option Price</label>
+            <input
+              type="number"
+              step="0.01"
+              value={optionPrice}
+              onChange={(e) => setOptionPrice(parseFloat(e.target.value) || 0)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Underlying Price at Close</label>
+            <input
+              type="number"
+              step="0.01"
+              value={underlyingPrice}
+              onChange={(e) => setUnderlyingPrice(parseFloat(e.target.value) || 0)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+            />
+          </div>
+          <div className={`p-2 rounded text-sm font-medium ${itm ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'}`}> 
+            {itm ? 'In the Money' : 'Out of the Money'}
+          </div>
+          <div className="text-sm">
+            Final P/L: <span className={result.ifSoldNow >= 0 ? 'text-green-600 font-medium' : 'text-red-600 font-medium'}>{formatProfitLoss(result.ifSoldNow)}</span>
+          </div>
+        </div>
+        <div className="flex gap-3">
+          <Button variant="secondary" onClick={onCancel} className="flex-1">Cancel</Button>
+          <Button onClick={handleClose} className="flex-1">Close Position</Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CloseContractModal;

--- a/src/components/contracts/ContractCard.tsx
+++ b/src/components/contracts/ContractCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Trash2, Calendar, Eye, Copy, Edit } from 'lucide-react';
+import { Trash2, Calendar, Eye, Copy, Edit, XCircle } from 'lucide-react';
 import type { OptionContract } from '../../models/OptionContract';
 import { formatCurrency, formatProfitLoss } from '../../utils/formatters';
 import Button from '../common/Button';
@@ -10,14 +10,16 @@ interface ContractCardProps {
   onDelete: () => void;
   onClone: () => void;
   onEdit: () => void;
+  onClose: () => void;
 }
 
-const ContractCard: React.FC<ContractCardProps> = ({ 
-  contract, 
-  onClick, 
-  onDelete, 
-  onClone, 
-  onEdit 
+const ContractCard: React.FC<ContractCardProps> = ({
+  contract,
+  onClick,
+  onDelete,
+  onClone,
+  onEdit,
+  onClose
 }) => {
   const isCredit = contract.expectedCreditOrDebit > 0;
   const formatDate = (dateString: string) => new Date(dateString).toLocaleDateString();
@@ -59,21 +61,31 @@ const ContractCard: React.FC<ContractCardProps> = ({
             >
               <Edit className="h-4 w-4 text-green-500" />
             </button>
-            <button
-              onClick={(e) => {
-                e.stopPropagation();
-                onClone?.();
-              }}
-              className="p-1.5 hover:bg-blue-50 rounded-lg"
-              title="Clone and edit contract"
-            >
-              <Copy className="h-4 w-4 text-blue-500" />
-            </button>
-            <button
-              onClick={(e) => {
-                e.stopPropagation();
-                onDelete();
-              }}
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              onClone?.();
+            }}
+            className="p-1.5 hover:bg-blue-50 rounded-lg"
+            title="Clone and edit contract"
+          >
+            <Copy className="h-4 w-4 text-blue-500" />
+          </button>
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              onClose?.();
+            }}
+            className="p-1.5 hover:bg-yellow-50 rounded-lg"
+            title="Close position"
+          >
+            <XCircle className="h-4 w-4 text-yellow-600" />
+          </button>
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              onDelete();
+            }}
               className="p-1.5 hover:bg-red-50 rounded-lg"
               title="Delete contract"
             >

--- a/src/components/contracts/ContractList.tsx
+++ b/src/components/contracts/ContractList.tsx
@@ -8,6 +8,7 @@ import { formatProfitLoss, getProfitLossColor } from '../../utils/formatters';
 import Button from '../common/Button';
 import ContractCard from './ContractCard';
 import PortfolioAnalytics from '../portfolio/PortfolioAnalytics';
+import CloseContractModal from './CloseContractModal';
 
 interface ContractListProps {
   onViewContract: (contract: OptionContract) => void;
@@ -27,6 +28,7 @@ const ContractList: React.FC<ContractListProps> = ({
   const { deleteContract, getActiveContracts } = useContracts();
   const activeContracts = getActiveContracts();
   const [showDeleteConfirm, setShowDeleteConfirm] = useState<string | null>(null);
+  const [closingContract, setClosingContract] = useState<OptionContract | null>(null);
   const [selectedGroup, setSelectedGroup] = useState<PortfolioGroup | null>(null);
   const [groupSimPrices, setGroupSimPrices] = useState<Record<string, number>>({});
 
@@ -229,9 +231,18 @@ const ContractList: React.FC<ContractListProps> = ({
                   onEditContract(contractData as OptionContract);
                 }}
                 onEdit={() => onEditContract(contract)}
+                onClose={() => setClosingContract(contract)}
               />
             ))}
           </div>
+        )}
+
+        {closingContract && (
+          <CloseContractModal
+            contract={closingContract}
+            onDone={() => setClosingContract(null)}
+            onCancel={() => setClosingContract(null)}
+          />
         )}
 
         {/* Delete Confirmation Modal */}

--- a/src/components/contracts/ExpiredOptionsPage.tsx
+++ b/src/components/contracts/ExpiredOptionsPage.tsx
@@ -25,6 +25,11 @@ const ExpiredOptionsPage: React.FC<ExpiredOptionsPageProps> = ({ onBack, onExpir
     whatWentRight: '',
     whatWentWrong: ''
   });
+  const isITM = selectedContract
+    ? selectedContract.optionType === 'call'
+      ? finalPrice > selectedContract.strikePrice
+      : finalPrice < selectedContract.strikePrice
+    : false;
 
   const expiringToday = activeContracts.filter(contract => {
     const today = new Date();
@@ -233,6 +238,11 @@ const ExpiredOptionsPage: React.FC<ExpiredOptionsPageProps> = ({ onBack, onExpir
                     className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                     placeholder="Enter final stock price"
                   />
+                  {finalPrice > 0 && (
+                    <p className={`mt-2 text-sm font-medium ${isITM ? 'text-green-600' : 'text-red-600'}`}> 
+                      {isITM ? 'In the Money' : 'Out of the Money'}
+                    </p>
+                  )}
                 </div>
                 
                 <div>

--- a/src/context/ContractsContext.tsx
+++ b/src/context/ContractsContext.tsx
@@ -1,13 +1,15 @@
 import React, { createContext, useContext, useReducer, useEffect } from 'react';
 import type { OptionContract } from '../models/OptionContract';
 import { contractsApi } from '../services/api';
+import { calculateProfitLoss } from '../utils/profitLossCalculator';
 
 type ContractsAction =
   | { type: 'SET_CONTRACTS'; payload: OptionContract[] }
   | { type: 'ADD_CONTRACT'; payload: OptionContract }
   | { type: 'DELETE_CONTRACT'; payload: string }
   | { type: 'UPDATE_CONTRACT'; payload: OptionContract }
-  | { type: 'EXPIRE_CONTRACT'; payload: { id: string; finalData: Partial<OptionContract> } };
+  | { type: 'EXPIRE_CONTRACT'; payload: { id: string; finalData: Partial<OptionContract> } }
+  | { type: 'CLOSE_CONTRACT'; payload: { id: string; finalData: Partial<OptionContract> } };
 
 interface ContractsState {
   contracts: OptionContract[];
@@ -18,6 +20,7 @@ interface ContractsContextType extends ContractsState {
   updateContract: (contract: OptionContract) => Promise<void>;
   deleteContract: (id: string) => void;
   expireContract: (id: string, finalUnderlyingPrice: number, analysis?: OptionContract['analysis']) => Promise<void>;
+  closeContract: (id: string, closingOptionPrice: number, closingUnderlyingPrice: number) => Promise<void>;
   getActiveContracts: () => OptionContract[];
   getExpiredContracts: () => OptionContract[];
   checkAndUpdateExpiredContracts: () => void;
@@ -41,9 +44,17 @@ const contractsReducer = (state: ContractsState, action: ContractsAction): Contr
       };
     case 'EXPIRE_CONTRACT':
       return {
-        contracts: state.contracts.map(c => 
-          c.id === action.payload.id 
+        contracts: state.contracts.map(c =>
+          c.id === action.payload.id
             ? { ...c, ...action.payload.finalData, status: 'expired' as const }
+            : c
+        )
+      };
+    case 'CLOSE_CONTRACT':
+      return {
+        contracts: state.contracts.map(c =>
+          c.id === action.payload.id
+            ? { ...c, ...action.payload.finalData, status: 'closed' as const }
             : c
         )
       };
@@ -125,6 +136,36 @@ export const ContractsProvider: React.FC<{ children: React.ReactNode }> = ({ chi
     }
   };
 
+  const closeContract = async (
+    id: string,
+    closingOptionPrice: number,
+    closingUnderlyingPrice: number
+  ) => {
+    try {
+      const contract = state.contracts.find(c => c.id === id);
+      if (!contract) return;
+
+      const result = calculateProfitLoss(
+        contract,
+        closingUnderlyingPrice,
+        closingOptionPrice
+      );
+
+      const finalData = {
+        status: 'closed' as const,
+        finalUnderlyingPrice: closingUnderlyingPrice,
+        finalProfitLoss: result.ifSoldNow,
+        closedDate: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      };
+
+      const updatedContract = await contractsApi.update(id, { ...contract, ...finalData });
+      dispatch({ type: 'CLOSE_CONTRACT', payload: { id, finalData } });
+    } catch (error) {
+      console.error('Failed to close contract:', error);
+    }
+  };
+
   const getActiveContracts = () => state.contracts.filter(c => c.status !== 'expired' && c.status !== 'closed');
   
   const getExpiredContracts = () => state.contracts.filter(c => c.status === 'expired' || c.status === 'closed');
@@ -158,11 +199,12 @@ export const ContractsProvider: React.FC<{ children: React.ReactNode }> = ({ chi
       ...state, 
       addContract, 
       updateContract, 
-      deleteContract, 
-      expireContract, 
-      getActiveContracts, 
+      deleteContract,
+      expireContract,
+      closeContract,
+      getActiveContracts,
       getExpiredContracts,
-      checkAndUpdateExpiredContracts 
+      checkAndUpdateExpiredContracts
     }}>
       {children}
     </ContractsContext.Provider>

--- a/src/utils/profitLossCalculator.ts
+++ b/src/utils/profitLossCalculator.ts
@@ -42,7 +42,8 @@ export const calculateProfitLoss = (
   }
 
   // P/L if closed now
-  const cashOnClose = currentPrice * contracts * 100 * (buyOrSell === 'buy' ? -1 : 1);
+  // Long positions receive cash when selling to close, short positions pay cash
+  const cashOnClose = currentPrice * contracts * 100 * (buyOrSell === 'buy' ? 1 : -1);
   const ifSoldNow = totalPremium + cashOnClose;
 
   // P/L at expiration


### PR DESCRIPTION
## Summary
- fix profit/loss calculation when closing a position
- add ability to close contracts before expiry
- show a closing modal for contracts with final P/L and ITM/OTM status
- display ITM/OTM indicator when expiring a contract

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68717f5db1248330a4dd94de18a98add