### PR TITLE
Implement risk indicators and payoff thumbnails

### DIFF
--- a/src/components/contracts/ContractCard.tsx
+++ b/src/components/contracts/ContractCard.tsx
@@ -3,6 +3,9 @@ import { Trash2, Calendar, Eye, Copy, Edit } from 'lucide-react';
 import type { OptionContract } from '../../models/OptionContract';
 import { formatCurrency, formatProfitLoss } from '../../utils/formatters';
 import Button from '../common/Button';
+// US-3 imports for risk display and payoff thumbnail
+import PayoffDiagram from './PayoffDiagram';
+import { calculateRisk, getRiskColor } from '../../utils/riskCalculator';
 
 interface ContractCardProps {
   contract: OptionContract;
@@ -21,11 +24,13 @@ const ContractCard: React.FC<ContractCardProps> = ({
 }) => {
   const isCredit = contract.expectedCreditOrDebit > 0;
   const formatDate = (dateString: string) => new Date(dateString).toLocaleDateString();
-  
+
   const today = new Date();
   const expiry = new Date(contract.expirationDate);
   const daysToExpiry = Math.ceil((expiry.getTime() - today.getTime()) / (1000 * 60 * 60 * 24));
   const isExpiringSoon = daysToExpiry <= 7;
+  // Calculate risk scores for US-3 visual indicators
+  const risk = calculateRisk(contract);
 
   return (
     <div className="bg-white rounded-2xl shadow-sm border border-gray-100 overflow-hidden hover:shadow-lg transition-all duration-200 group">
@@ -89,6 +94,40 @@ const ContractCard: React.FC<ContractCardProps> = ({
           <span className="text-sm text-gray-500 font-medium">
             {contract.contracts} contract{contract.contracts !== 1 ? 's' : ''}
           </span>
+        </div>
+      </div>
+
+      {/* Risk Bars & Payoff Diagram - US-3 */}
+      <div className="px-4 pb-3 flex gap-3">
+        <PayoffDiagram contract={contract} width={80} height={50} />
+        <div className="flex-1 space-y-1 text-xs">
+          <div className="flex items-center gap-2">
+            <span className="w-16 text-gray-500">Decay</span>
+            <div className="flex-1 h-2 bg-gray-100 rounded">
+              <div
+                className={`h-2 rounded ${getRiskColor(risk.timeDecay)}`}
+                style={{ width: `${risk.timeDecay * 100}%` }}
+              />
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="w-16 text-gray-500">Delta</span>
+            <div className="flex-1 h-2 bg-gray-100 rounded">
+              <div
+                className={`h-2 rounded ${getRiskColor(risk.delta)}`}
+                style={{ width: `${risk.delta * 100}%` }}
+              />
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="w-16 text-gray-500">Vol</span>
+            <div className="flex-1 h-2 bg-gray-100 rounded">
+              <div
+                className={`h-2 rounded ${getRiskColor(risk.volatility)}`}
+                style={{ width: `${risk.volatility * 100}%` }}
+              />
+            </div>
+          </div>
         </div>
       </div>
 

--- a/src/components/contracts/PayoffDiagram.tsx
+++ b/src/components/contracts/PayoffDiagram.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import type { OptionContract } from '../../models/OptionContract';
+import { calculateProfitLoss } from '../../utils/profitLossCalculator';
+
+interface PayoffDiagramProps {
+  contract: OptionContract;
+  width?: number;
+  height?: number;
+}
+
+// Renders a simple payoff diagram as an inline SVG thumbnail
+const PayoffDiagram: React.FC<PayoffDiagramProps> = ({ contract, width = 120, height = 80 }) => {
+  const rangeFactor = 0.5; // +/-50% around strike
+  const minPrice = contract.strikePrice * (1 - rangeFactor);
+  const maxPrice = contract.strikePrice * (1 + rangeFactor);
+  const steps = 20;
+  const step = (maxPrice - minPrice) / steps;
+
+  const plValues: number[] = [];
+  for (let i = 0; i <= steps; i++) {
+    const price = minPrice + step * i;
+    const { ifExercisedAtExpiration } = calculateProfitLoss(contract, price);
+    plValues.push(ifExercisedAtExpiration);
+  }
+
+  const maxPL = Math.max(...plValues);
+  const minPL = Math.min(...plValues);
+  const range = maxPL - minPL || 1;
+
+  const points = plValues
+    .map((pl, i) => {
+      const x = (i / steps) * width;
+      const y = height - ((pl - minPL) / range) * height;
+      return `${x},${y}`;
+    })
+    .join(' ');
+
+  const breakevenY = height - ((0 - minPL) / range) * height;
+
+  return (
+    <svg width={width} height={height} className="text-blue-600">
+      <polyline fill="none" stroke="currentColor" strokeWidth="2" points={points} />
+      <line x1={0} x2={width} y1={breakevenY} y2={breakevenY} stroke="#d1d5db" strokeWidth="1" />
+    </svg>
+  );
+};
+
+export default PayoffDiagram;

--- a/src/utils/riskCalculator.ts
+++ b/src/utils/riskCalculator.ts
@@ -1,0 +1,32 @@
+export interface RiskBreakdown {
+  timeDecay: number;
+  delta: number;
+  volatility: number;
+}
+
+import type { OptionContract } from '../models/OptionContract';
+
+// Calculate simple risk scores between 0 and 1
+export const calculateRisk = (contract: OptionContract): RiskBreakdown => {
+  const today = new Date();
+  const expiry = new Date(contract.expirationDate);
+  const daysToExpiry = Math.max(0, (expiry.getTime() - today.getTime()) / (1000 * 60 * 60 * 24));
+
+  // Time decay risk increases as expiration approaches
+  const timeDecay = daysToExpiry <= 0 ? 1 : Math.min(1, 30 / daysToExpiry);
+
+  // Use chance of profit as inverse proxy for delta risk
+  const delta = 1 - contract.chanceOfProfit / 100;
+
+  // Volatility risk based on recent percent change of option price
+  const volatility = Math.min(1, Math.abs(contract.percentChange) / 10);
+
+  return { timeDecay, delta, volatility };
+};
+
+// Map a risk score to a Tailwind color class
+export const getRiskColor = (score: number): string => {
+  if (score < 0.33) return 'bg-green-500';
+  if (score < 0.66) return 'bg-yellow-500';
+  return 'bg-red-500';
+};


### PR DESCRIPTION
## Summary
- add PayoffDiagram component for contract cards
- provide riskCalculator utility for risk scores and color mapping
- update ContractCard with risk bars and payoff diagram thumbnail

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: 28 errors, 1 warning)*

------
https://chatgpt.com/codex/tasks/task_e_6873498dad0c83308207dfb40ee9da45