### PR TITLE
Implement US-18 quick simulator

### DIFF
--- a/src/components/contracts/ContractList.tsx
+++ b/src/components/contracts/ContractList.tsx
@@ -10,6 +10,8 @@ import ContractCard from './ContractCard';
 import ContractTable from './ContractTable';
 import PortfolioAnalytics from '../portfolio/PortfolioAnalytics';
 import GroupedContractView from './GroupedContractView';
+// US-18 QuickSimulator import
+import QuickSimulator from './QuickSimulator';
 
 interface ContractListProps {
   onViewContract: (contract: OptionContract) => void;
@@ -151,6 +153,18 @@ const ContractList: React.FC<ContractListProps> = ({
         {/* Analytics Dashboard */}
         <PortfolioAnalytics contracts={displayContracts} />
 
+        {/* US-18 Quick Simulator for selected underlying */}
+        {selectedGroup && (
+          <QuickSimulator
+            symbol={selectedGroup.symbol}
+            contracts={selectedGroup.contracts}
+            initialPrice={groupSimPrices[selectedGroup.symbol]}
+            onPriceChange={(price) =>
+              setGroupSimPrices(prev => ({ ...prev, [selectedGroup.symbol]: price }))
+            }
+          />
+        )}
+
         {/* Portfolio Groups Overview - only show when viewing all contracts */}
         {!groupView && !selectedGroup && portfolioGroups.length > 1 && (
           <div className="bg-white rounded-2xl shadow-sm border border-gray-100 p-6 mb-8">
@@ -271,9 +285,11 @@ const ContractList: React.FC<ContractListProps> = ({
           ) : (
             <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
               {displayContracts.map(contract => (
+                // US-18 pass simulator price when viewing a specific underlying
                 <ContractCard
                   key={contract.id}
                   contract={contract}
+                  simPrice={selectedGroup ? groupSimPrices[selectedGroup.symbol] : undefined}
                   onClick={() => onViewContract(contract)}
                   onDelete={() => setShowDeleteConfirm(contract.id)}
                   onClone={() => {

--- a/src/components/contracts/QuickSimulator.tsx
+++ b/src/components/contracts/QuickSimulator.tsx
@@ -1,0 +1,67 @@
+import React, { useState } from 'react';
+import type { OptionContract } from '../../models/OptionContract';
+import { calculateProfitLoss } from '../../utils/profitLossCalculator';
+import { formatProfitLoss, getProfitLossColor } from '../../utils/formatters';
+import Input from '../common/Input';
+
+interface QuickSimulatorProps {
+  symbol: string;
+  contracts: OptionContract[];
+  initialPrice?: number;
+  onPriceChange: (price: number) => void;
+}
+
+// US-18 Quick Simulator component for entering a hypothetical underlying price
+const QuickSimulator: React.FC<QuickSimulatorProps> = ({
+  symbol,
+  contracts,
+  initialPrice = 0,
+  onPriceChange
+}) => {
+  const [price, setPrice] = useState(initialPrice ? String(initialPrice) : '');
+  const [error, setError] = useState('');
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setPrice(value);
+    if (!value) {
+      setError('');
+      onPriceChange(0);
+      return;
+    }
+    const num = parseFloat(value);
+    if (isNaN(num) || num <= 0) {
+      setError('Please enter a positive number');
+      onPriceChange(NaN);
+    } else {
+      setError('');
+      onPriceChange(num);
+    }
+  };
+
+  const simPrice = parseFloat(price);
+  const isValid = !error && price !== '' && !isNaN(simPrice) && simPrice > 0;
+  const totalPL = isValid
+    ? contracts.reduce((sum, c) => sum + calculateProfitLoss(c, simPrice).ifSoldNow, 0)
+    : 0;
+
+  return (
+    <div className="bg-white rounded-2xl shadow-sm border border-gray-100 p-4 mb-6">
+      <h3 className="text-lg font-semibold text-gray-900 mb-2">Quick Simulator</h3>
+      <Input
+        label={`Underlying Price for ${symbol}`}
+        type="number"
+        step="0.01"
+        value={price}
+        onChange={handleChange}
+        error={error}
+        className="mb-2"
+      />
+      {isValid && (
+        <p className={`text-sm font-medium ${getProfitLossColor(totalPL)}`}>Total P/L: {formatProfitLoss(totalPL)}</p>
+      )}
+    </div>
+  );
+};
+
+export default QuickSimulator;


### PR DESCRIPTION
## Summary
- add QuickSimulator component for hypothetical price input
- show quick simulator when viewing a single underlying
- display simulated P/L per contract

## Testing
- `npm test -- -w=false`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68734b4a49cc8330a26a9ccb6c6b208d