### PR TITLE
Implement US-5 draggable dashboard widgets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,9 @@
       "dependencies": {
         "lucide-react": "^0.525.0",
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "react-grid-layout": "^1.5.2",
+        "react-resizable": "^3.0.5"
       },
       "devDependencies": {
         "@eslint/js": "^9.30.1",
@@ -2543,6 +2545,15 @@
         "node": ">= 6"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -3040,6 +3051,12 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-equals": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-4.0.3.tgz",
+      "integrity": "sha512-G3BSX9cfKttjr+2o1O22tYMLq0DPluZnYtq1rXumE1SpL/F/SLIfHx08WYQoWSIpeMYf8sRbJ8++71+v6Pnxfg==",
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -3546,7 +3563,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -3719,6 +3735,18 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
     },
     "node_modules/loupe": {
       "version": "3.1.4",
@@ -3907,7 +3935,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4317,6 +4344,23 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -4369,6 +4413,38 @@
         "react": "^19.1.0"
       }
     },
+    "node_modules/react-draggable": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.5.0.tgz",
+      "integrity": "sha512-VC+HBLEZ0XJxnOxVAZsdRi8rD04Iz3SiiKOoYzamjylUcju/hP9np/aZdLHf/7WOD268WMoNJMvYfB5yAK45cw==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0",
+        "react-dom": ">= 16.3.0"
+      }
+    },
+    "node_modules/react-grid-layout": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/react-grid-layout/-/react-grid-layout-1.5.2.tgz",
+      "integrity": "sha512-vT7xmQqszTT+sQw/LfisrEO4le1EPNnSEMVHy6sBZyzS3yGkMywdOd+5iEFFwQwt0NSaGkxuRmYwa1JsP6OJdw==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1",
+        "fast-equals": "^4.0.3",
+        "prop-types": "^15.8.1",
+        "react-draggable": "^4.4.6",
+        "react-resizable": "^3.0.5",
+        "resize-observer-polyfill": "^1.5.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0",
+        "react-dom": ">= 16.3.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -4385,6 +4461,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-resizable": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/react-resizable/-/react-resizable-3.0.5.tgz",
+      "integrity": "sha512-vKpeHhI5OZvYn82kXOs1bC8aOXktGU5AmKAgaZS4F5JPburCtbmDPqE7Pzp+1kN4+Wb81LlF33VpGwWwtXem+w==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "15.x",
+        "react-draggable": "^4.0.3"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3"
       }
     },
     "node_modules/read-cache": {
@@ -4423,6 +4512,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.10",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
   "dependencies": {
     "lucide-react": "^0.525.0",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "react-grid-layout": "^1.5.2",
+    "react-resizable": "^3.0.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",

--- a/src/components/dashboard/DashboardLayout.tsx
+++ b/src/components/dashboard/DashboardLayout.tsx
@@ -1,0 +1,86 @@
+import React, { useState } from 'react';
+import GridLayout, { WidthProvider, Layout } from 'react-grid-layout';
+import 'react-grid-layout/css/styles.css';
+import 'react-resizable/css/styles.css';
+import DashboardWidget from './DashboardWidget';
+import { useDashboardLayout } from '../../hooks/useDashboardLayout';
+import type { DashboardWidgetDefinition } from '../../types/dashboard';
+import Input from '../common/Input';
+import Select from '../common/Select';
+import Button from '../common/Button';
+
+const ReactGridLayout = WidthProvider(GridLayout);
+
+interface DashboardLayoutProps {
+  widgets: DashboardWidgetDefinition[];
+}
+
+// Component rendering a draggable/resizable dashboard and controls for saving layouts
+const DashboardLayout: React.FC<DashboardLayoutProps> = ({ widgets }) => {
+  const defaultLayout: Layout[] = widgets.map((w, idx) => ({
+    i: w.id,
+    x: (idx % 2) * 6,
+    y: Math.floor(idx / 2) * 4,
+    w: 6,
+    h: 4
+  }));
+
+  const {
+    layout,
+    onLayoutChange,
+    saveLayoutAs,
+    loadLayout,
+    savedLayouts,
+    currentLayoutName
+  } = useDashboardLayout(defaultLayout);
+
+  const [newName, setNewName] = useState('');
+
+  return (
+    <div>
+      <div className="flex flex-wrap items-end gap-4 mb-4">
+        <div className="w-40">
+          <Select
+            label="Layouts"
+            value={currentLayoutName}
+            onChange={(val) => loadLayout(val)}
+            options={savedLayouts.map(l => ({ value: l.name, label: l.name }))}
+          />
+        </div>
+        <div className="flex-1 max-w-xs">
+          <Input
+            label="Save As"
+            value={newName}
+            onChange={(e) => setNewName(e.target.value)}
+          />
+        </div>
+        <Button
+          onClick={() => {
+            if (newName.trim()) {
+              saveLayoutAs(newName.trim());
+              setNewName('');
+            }
+          }}
+        >
+          Save Layout
+        </Button>
+      </div>
+      <ReactGridLayout
+        className="layout"
+        layout={layout}
+        cols={12}
+        rowHeight={30}
+        onLayoutChange={onLayoutChange}
+        draggableHandle=".drag-handle"
+      >
+        {widgets.map(widget => (
+          <div key={widget.id} data-grid={layout.find(l => l.i === widget.id)}>
+            <DashboardWidget title={widget.title}>{widget.element}</DashboardWidget>
+          </div>
+        ))}
+      </ReactGridLayout>
+    </div>
+  );
+};
+
+export default DashboardLayout;

--- a/src/components/dashboard/DashboardWidget.tsx
+++ b/src/components/dashboard/DashboardWidget.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+interface DashboardWidgetProps {
+  title: string;
+  children: React.ReactNode;
+}
+
+const DashboardWidget: React.FC<DashboardWidgetProps> = ({ title, children }) => {
+  return (
+    <div className="h-full bg-white rounded-2xl shadow-sm border border-gray-100 flex flex-col">
+      {/* drag handle for react-grid-layout */}
+      <div className="drag-handle cursor-move px-3 py-2 border-b border-gray-200 bg-gray-50 text-sm font-medium">
+        {title}
+      </div>
+      <div className="p-4 flex-1 overflow-auto">
+        {children}
+      </div>
+    </div>
+  );
+};
+
+export default DashboardWidget;

--- a/src/hooks/useDashboardLayout.ts
+++ b/src/hooks/useDashboardLayout.ts
@@ -1,0 +1,65 @@
+import { useEffect, useState } from 'react';
+import type { Layout } from 'react-grid-layout';
+import { useLocalStorage } from './useLocalStorage';
+import type { DashboardSavedLayout } from '../types/dashboard';
+
+const DEFAULT_NAME = 'Default view';
+
+// Hook managing dashboard layouts with persistence in localStorage
+export function useDashboardLayout(defaultLayout: Layout[]) {
+  const [savedLayouts, setSavedLayouts] = useLocalStorage<DashboardSavedLayout[]>(
+    'dashboardLayouts',
+    [{ name: DEFAULT_NAME, layout: defaultLayout }]
+  );
+  const [currentLayoutName, setCurrentLayoutName] = useLocalStorage<string>(
+    'dashboardCurrentLayout',
+    DEFAULT_NAME
+  );
+  const [layout, setLayout] = useState<Layout[]>(() => {
+    const found = savedLayouts.find(l => l.name === currentLayoutName);
+    return found ? found.layout : defaultLayout;
+  });
+
+  useEffect(() => {
+    const found = savedLayouts.find(l => l.name === currentLayoutName);
+    if (found) setLayout(found.layout);
+  }, [currentLayoutName, savedLayouts]);
+
+  const onLayoutChange = (newLayout: Layout[]) => {
+    setLayout(newLayout);
+    setSavedLayouts(prev => prev.map(l => (l.name === currentLayoutName ? { ...l, layout: newLayout } : l)));
+  };
+
+  const saveLayoutAs = (name: string) => {
+    setSavedLayouts(prev => {
+      const others = prev.filter(l => l.name !== name);
+      return [...others, { name, layout }];
+    });
+    setCurrentLayoutName(name);
+  };
+
+  const loadLayout = (name: string) => {
+    const found = savedLayouts.find(l => l.name === name);
+    if (found) {
+      setCurrentLayoutName(name);
+      setLayout(found.layout);
+    }
+  };
+
+  const deleteLayout = (name: string) => {
+    setSavedLayouts(prev => prev.filter(l => l.name !== name));
+    if (currentLayoutName === name) {
+      setCurrentLayoutName(DEFAULT_NAME);
+    }
+  };
+
+  return {
+    layout,
+    onLayoutChange,
+    saveLayoutAs,
+    loadLayout,
+    deleteLayout,
+    savedLayouts,
+    currentLayoutName
+  };
+}

--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -1,0 +1,13 @@
+import { Layout } from 'react-grid-layout';
+import React from 'react';
+
+export interface DashboardWidgetDefinition {
+  id: string;
+  title: string;
+  element: React.ReactNode;
+}
+
+export interface DashboardSavedLayout {
+  name: string;
+  layout: Layout[];
+}


### PR DESCRIPTION
## Summary
- install `react-grid-layout` and `react-resizable`
- add dashboard layout types
- create `DashboardWidget` wrapper
- create `DashboardLayout` component for draggable widget layout
- implement `useDashboardLayout` hook for layout persistence

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68734e3e089883309f13004af081a374