### PR TITLE
Implement US-20 portfolio tracking

### DIFF
--- a/src/components/portfolio/HoldingsManager.tsx
+++ b/src/components/portfolio/HoldingsManager.tsx
@@ -1,0 +1,83 @@
+import React, { useState } from 'react';
+import Input from '../common/Input';
+import Button from '../common/Button';
+import { usePortfolio } from '../../context/PortfolioContext';
+import type { Holding } from '../../models/Portfolio';
+
+interface HoldingsManagerProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+// Modal form for adding and editing underlying holdings
+const HoldingsManager: React.FC<HoldingsManagerProps> = ({ open, onClose }) => {
+  const { holdings, addHolding, updateHolding, removeHolding } = usePortfolio();
+  const [editing, setEditing] = useState<Holding | null>(null);
+  const [symbol, setSymbol] = useState('');
+  const [shares, setShares] = useState('');
+  const [price, setPrice] = useState('');
+  const [error, setError] = useState('');
+
+  if (!open) return null;
+
+  const resetForm = () => {
+    setEditing(null);
+    setSymbol('');
+    setShares('');
+    setPrice('');
+    setError('');
+  };
+
+  const handleSubmit = () => {
+    const qty = parseFloat(shares);
+    const pr = parseFloat(price);
+    if (!symbol || qty <= 0 || pr <= 0 || isNaN(qty) || isNaN(pr)) {
+      setError('Enter valid symbol, shares and price');
+      return;
+    }
+    if (editing) {
+      updateHolding({ ...editing, symbol, shares: qty, price: pr });
+    } else {
+      addHolding({ symbol, shares: qty, price: pr });
+    }
+    resetForm();
+  };
+
+  const handleEdit = (h: Holding) => {
+    setEditing(h);
+    setSymbol(h.symbol);
+    setShares(h.shares.toString());
+    setPrice(h.price.toString());
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-white rounded-2xl p-6 max-w-xl w-full mx-4 shadow-2xl">
+        <h3 className="text-lg font-semibold text-gray-900 mb-4">Manage Holdings</h3>
+        <div className="space-y-2 mb-4 max-h-40 overflow-y-auto">
+          {holdings.map(h => (
+            <div key={h.id} className="flex items-center justify-between border-b border-gray-200 pb-1">
+              <span className="font-medium">{h.symbol}: {h.shares} @ ${h.price}</span>
+              <div className="flex gap-2">
+                <button onClick={() => handleEdit(h)} className="text-blue-600 text-sm">Edit</button>
+                <button onClick={() => removeHolding(h.id)} className="text-red-600 text-sm">Delete</button>
+              </div>
+            </div>
+          ))}
+        </div>
+        <div className="grid md:grid-cols-3 gap-4 mb-4">
+          <Input label="Symbol" value={symbol} onChange={e => setSymbol(e.target.value)} className="mb-0" />
+          <Input label="Shares" type="number" value={shares} onChange={e => setShares(e.target.value)} className="mb-0" />
+          <Input label="Price" type="number" step="0.01" value={price} onChange={e => setPrice(e.target.value)} className="mb-0" />
+        </div>
+        {error && <p className="text-red-600 text-sm mb-2">{error}</p>}
+        <div className="flex gap-3 justify-end">
+          <Button variant="secondary" onClick={() => { resetForm(); onClose(); }} className="flex-1 md:flex-none">Cancel</Button>
+          <Button onClick={handleSubmit} className="flex-1 md:flex-none">{editing ? 'Update' : 'Add'}</Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default HoldingsManager;

--- a/src/components/portfolio/PortfolioHeader.tsx
+++ b/src/components/portfolio/PortfolioHeader.tsx
@@ -1,0 +1,49 @@
+import React, { useState, useEffect } from 'react';
+import Input from '../common/Input';
+import { usePortfolio } from '../../context/PortfolioContext';
+
+// Header component allowing user to input cash balance
+const PortfolioHeader: React.FC = () => {
+  const { cash, setCash } = usePortfolio();
+  const [value, setValue] = useState('');
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    setValue(cash.toString());
+  }, [cash]);
+
+  const handleBlur = () => {
+    const num = parseFloat(value);
+    if (isNaN(num) || num < 0) {
+      setError('Cash balance cannot be negative');
+      return;
+    }
+    setError('');
+    setCash(num);
+  };
+
+  const lowCash = !error && parseFloat(value) >= 0 && parseFloat(value) < 1000;
+
+  return (
+    <div className="bg-white rounded-2xl shadow-sm border border-gray-100 p-4 mb-4">
+      <div className="flex items-end gap-4">
+        <div className="flex-1">
+          <Input
+            label="Cash Balance"
+            type="number"
+            step="0.01"
+            value={value}
+            onChange={e => setValue(e.target.value)}
+            onBlur={handleBlur}
+            error={error}
+          />
+        </div>
+        {lowCash && (
+          <span className="text-sm text-orange-600 font-medium">Low cash</span>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default PortfolioHeader;

--- a/src/components/portfolio/PortfolioSummary.tsx
+++ b/src/components/portfolio/PortfolioSummary.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { usePortfolio } from '../../context/PortfolioContext';
+import { useContracts } from '../../context/ContractsContext';
+import { calculateHoldingsValue, calculateNetProfitLoss, calculateTotalPortfolioValue } from '../../utils/portfolioCalculations';
+import { formatProfitLoss, getProfitLossColor } from '../../utils/formatters';
+
+// Display portfolio totals: cash, holdings value, contract P/L and overall total
+const PortfolioSummary: React.FC = () => {
+  const { cash, holdings } = usePortfolio();
+  const { contracts } = useContracts();
+
+  const holdingsValue = calculateHoldingsValue(holdings);
+  const netPL = calculateNetProfitLoss(contracts);
+  const total = calculateTotalPortfolioValue(cash, holdings, contracts);
+
+  return (
+    <div className="bg-white rounded-2xl shadow-sm border border-gray-100 p-6">
+      <h3 className="text-lg font-semibold text-gray-900 mb-4">Portfolio Summary</h3>
+      <div className="space-y-2 text-sm">
+        <div className="flex justify-between">
+          <span>Cash</span>
+          <span className={getProfitLossColor(cash)}>{formatProfitLoss(cash)}</span>
+        </div>
+        <div className="flex justify-between">
+          <span>Holdings</span>
+          <span className={getProfitLossColor(holdingsValue)}>{formatProfitLoss(holdingsValue)}</span>
+        </div>
+        <div className="flex justify-between">
+          <span>Net P/L</span>
+          <span className={getProfitLossColor(netPL)}>{formatProfitLoss(netPL)}</span>
+        </div>
+        <div className="flex justify-between font-bold border-t pt-2">
+          <span>Total Value</span>
+          <span className={getProfitLossColor(total)}>{formatProfitLoss(total)}</span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PortfolioSummary;

--- a/src/context/PortfolioContext.tsx
+++ b/src/context/PortfolioContext.tsx
@@ -1,0 +1,41 @@
+import React, { createContext, useContext } from 'react';
+import { useLocalStorage } from '../hooks/useLocalStorage';
+import type { Holding, PortfolioState } from '../models/Portfolio';
+
+interface PortfolioContextType extends PortfolioState {
+  setCash: (amount: number) => void;
+  addHolding: (holding: Omit<Holding, 'id'>) => void;
+  updateHolding: (holding: Holding) => void;
+  removeHolding: (id: string) => void;
+}
+
+const PortfolioContext = createContext<PortfolioContextType | undefined>(undefined);
+
+export const PortfolioProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [cash, setCash] = useLocalStorage<number>('portfolioCash', 0);
+  const [holdings, setHoldings] = useLocalStorage<Holding[]>('portfolioHoldings', []);
+
+  const addHolding = (holding: Omit<Holding, 'id'>) => {
+    setHoldings(prev => [...prev, { ...holding, id: crypto.randomUUID() }]);
+  };
+
+  const updateHolding = (holding: Holding) => {
+    setHoldings(prev => prev.map(h => (h.id === holding.id ? holding : h)));
+  };
+
+  const removeHolding = (id: string) => {
+    setHoldings(prev => prev.filter(h => h.id !== id));
+  };
+
+  return (
+    <PortfolioContext.Provider value={{ cash, holdings, setCash, addHolding, updateHolding, removeHolding }}>
+      {children}
+    </PortfolioContext.Provider>
+  );
+};
+
+export const usePortfolio = () => {
+  const context = useContext(PortfolioContext);
+  if (!context) throw new Error('usePortfolio must be used within PortfolioProvider');
+  return context;
+};

--- a/src/models/Portfolio.ts
+++ b/src/models/Portfolio.ts
@@ -1,0 +1,20 @@
+// src/models/Portfolio.ts
+
+export interface Holding {
+  id: string;
+  symbol: string;
+  shares: number;
+  price: number; // price per share
+}
+
+export interface PortfolioState {
+  cash: number;
+  holdings: Holding[];
+}
+
+export interface PortfolioSummary {
+  cash: number;
+  holdingsValue: number;
+  netProfitLoss: number;
+  totalValue: number;
+}

--- a/src/utils/portfolioCalculations.ts
+++ b/src/utils/portfolioCalculations.ts
@@ -1,0 +1,21 @@
+import type { OptionContract } from '../models/OptionContract';
+import type { Holding } from '../models/Portfolio';
+
+// Calculate the total value of all recorded holdings
+export const calculateHoldingsValue = (holdings: Holding[]): number =>
+  holdings.reduce((sum, h) => sum + h.shares * h.price, 0);
+
+// Calculate net profit/loss from option contracts
+export const calculateNetProfitLoss = (contracts: OptionContract[]): number =>
+  contracts.reduce((sum, c) =>
+    sum + (typeof c.finalProfitLoss === 'number'
+      ? c.finalProfitLoss
+      : c.expectedCreditOrDebit * c.contracts * 100)
+  , 0);
+
+// Calculate overall portfolio value
+export const calculateTotalPortfolioValue = (
+  cash: number,
+  holdings: Holding[],
+  contracts: OptionContract[]
+): number => cash + calculateHoldingsValue(holdings) + calculateNetProfitLoss(contracts);


### PR DESCRIPTION
## Summary
- add context for portfolio cash and holdings
- add header component to update cash balance
- add holdings manager modal for underlying positions
- add summary card for total portfolio value
- create types and calculations utilities

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6873d1d5286c8330bb92cd7b2b047d6f